### PR TITLE
ApiFuture support added.

### DIFF
--- a/apifuture-common/pom.xml
+++ b/apifuture-common/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>future-converter-apifuture-common</artifactId>
+
+    <parent>
+        <groupId>net.javacrumbs.future-converter</groupId>
+        <artifactId>future-converter</artifactId>
+        <version>1.1.2-SNAPSHOT</version>
+    </parent>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.future-converter</groupId>
+            <artifactId>future-converter-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.api</groupId>
+            <artifactId>api-common</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>net.javacrumbs.futureconverter.apifuturecommon</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/apifuture-common/src/main/java/net/javacrumbs/futureconverter/apifuturecommon/ApiFutureUtils.java
+++ b/apifuture-common/src/main/java/net/javacrumbs/futureconverter/apifuturecommon/ApiFutureUtils.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.futureconverter.apifuturecommon;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.common.util.concurrent.MoreExecutors;
+import net.javacrumbs.futureconverter.common.internal.FutureWrapper;
+import net.javacrumbs.futureconverter.common.internal.ValueSource;
+import net.javacrumbs.futureconverter.common.internal.ValueSourceFuture;
+
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+
+public class ApiFutureUtils {
+    // *************************************** Converting to ApiFuture ******************************************
+
+    /**
+     * Creates api future from ValueSourceFuture. We have to send all Future API calls to ValueSourceFuture.
+     */
+    public static <T> ApiFuture<T> createApiFuture(ValueSourceFuture<T> valueSourceFuture) {
+        if (valueSourceFuture instanceof ApiFutureBackedValueSourceFuture) {
+            return ((ApiFutureBackedValueSourceFuture<T>) valueSourceFuture).getWrappedFuture();
+        } else {
+            return new ValueSourceFutureBackedApiFuture<>(valueSourceFuture);
+        }
+    }
+
+    public static <T> ApiFuture<T> createApiFuture(ValueSource<T> valueSource) {
+        if (valueSource instanceof ApiFutureBackedValueSourceFuture) {
+            return ((ApiFutureBackedValueSourceFuture<T>) valueSource).getWrappedFuture();
+        } else {
+            return new ValueSourceBackedApiFuture<>(valueSource);
+        }
+    }
+
+    /**
+     * If we have ValueSourceFuture, we can use it as the implementation and this class only converts
+     * listener registration.
+     */
+    private static class ValueSourceFutureBackedApiFuture<T> extends FutureWrapper<T> implements ApiFuture<T> {
+        ValueSourceFutureBackedApiFuture(ValueSourceFuture<T> valueSourceFuture) {
+            super(valueSourceFuture);
+        }
+
+        @Override
+        protected ValueSourceFuture<T> getWrappedFuture() {
+            return (ValueSourceFuture<T>) super.getWrappedFuture();
+        }
+
+        @Override
+        public void addListener(Runnable listener, Executor executor) {
+            getWrappedFuture().addCallbacks(value -> executor.execute(listener), ex -> executor.execute(listener));
+        }
+    }
+
+
+    /**
+     * If we only get ValueSource we have to create a ValueSourceFuture. Here we wrap Guavas SettableFuture
+     * and use it for listener handling and value storage.
+     */
+    private static class ValueSourceBackedApiFuture<T> extends FutureWrapper<T> implements ApiFuture<T> {
+        private final ValueSource<T> valueSource;
+
+        private ValueSourceBackedApiFuture(ValueSource<T> valueSource) {
+            super(com.google.common.util.concurrent.SettableFuture.create());
+            this.valueSource = valueSource;
+            valueSource.addCallbacks(value -> getWrappedFuture().set(value), ex -> getWrappedFuture().setException(ex));
+        }
+
+        @Override
+        public void addListener(Runnable listener, Executor executor) {
+            getWrappedFuture().addListener(listener, executor);
+        }
+
+        @Override
+        protected com.google.common.util.concurrent.SettableFuture<T> getWrappedFuture() {
+            return (com.google.common.util.concurrent.SettableFuture<T>) super.getWrappedFuture();
+        }
+
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            valueSource.cancel(mayInterruptIfRunning);
+            return super.cancel(mayInterruptIfRunning);
+        }
+
+        private ValueSource<T> getValueSource() {
+            return valueSource;
+        }
+    }
+
+
+    // *************************************** Converting from ApiFuture ******************************************
+    public static <T> ValueSourceFuture<T> createValueSourceFuture(ApiFuture<T> apiFuture) {
+        if (apiFuture instanceof ValueSourceFutureBackedApiFuture) {
+            return ((ValueSourceFutureBackedApiFuture<T>) apiFuture).getWrappedFuture();
+        } else {
+            return new ApiFutureBackedValueSourceFuture<>(apiFuture);
+        }
+    }
+
+    public static <T> ValueSource<T> createValueSource(ApiFuture<T> apiFuture) {
+        if (apiFuture instanceof ValueSourceBackedApiFuture) {
+            return ((ValueSourceBackedApiFuture<T>) apiFuture).getValueSource();
+        } else {
+            return new ApiFutureBackedValueSourceFuture<>(apiFuture);
+        }
+    }
+
+    /**
+     * Wraps ApiFuture and exposes it as ValueSourceFuture.
+     */
+    private static class ApiFutureBackedValueSourceFuture<T> extends ValueSourceFuture<T> {
+        private ApiFutureBackedValueSourceFuture(ApiFuture<T> wrappedFuture) {
+            super(wrappedFuture);
+        }
+
+        @Override
+        public void addCallbacks(Consumer<T> successCallback, Consumer<Throwable> failureCallback) {
+            ApiFutures.addCallback(getWrappedFuture(), new ApiFutureCallback<T>() {
+                @Override
+                public void onSuccess(T result) {
+                    successCallback.accept(result);
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
+                    failureCallback.accept(t);
+
+                }
+            }, MoreExecutors.directExecutor());
+        }
+
+
+        @Override
+        protected ApiFuture<T> getWrappedFuture() {
+            return (ApiFuture<T>) super.getWrappedFuture();
+        }
+    }
+}

--- a/common-test/pom.xml
+++ b/common-test/pom.xml
@@ -27,6 +27,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.api</groupId>
+            <artifactId>api-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava</artifactId>
             <optional>true</optional>

--- a/common-test/src/main/java/net/javacrumbs/futureconverter/common/test/apicommon/ApiCommonConvertedFutureTestHelper.java
+++ b/common-test/src/main/java/net/javacrumbs/futureconverter/common/test/apicommon/ApiCommonConvertedFutureTestHelper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.futureconverter.common.test.apicommon;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.common.util.concurrent.MoreExecutors;
+import net.javacrumbs.futureconverter.common.test.AbstractConverterTest;
+import net.javacrumbs.futureconverter.common.test.ConvertedFutureTestHelper;
+import net.javacrumbs.futureconverter.common.test.common.CommonConvertedFutureTestHelper;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ApiCommonConvertedFutureTestHelper extends CommonConvertedFutureTestHelper implements ConvertedFutureTestHelper<ApiFuture<String>> {
+    private final ApiFutureCallback<String> callback = mock(ApiFutureCallback.class);
+
+    @Override
+    public void waitForCalculationToFinish(ApiFuture<String> convertedFuture) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        ApiFutures.addCallback(convertedFuture, new ApiFutureCallback<String>() {
+            @Override
+            public void onSuccess(String result) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                latch.countDown();
+            }
+        }, MoreExecutors.directExecutor());
+
+        latch.await(1, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void verifyCallbackCalledWithException(Exception exception) {
+        waitForCallback();
+        verify(callback).onFailure(exception);
+    }
+
+    @Override
+    public void verifyCallbackCalledWithException(Class<? extends Exception> exceptionClass) {
+        waitForCallback();
+        verify(callback).onFailure(any(exceptionClass));
+    }
+
+    @Override
+    public void verifyCallbackCalledWithCorrectValue() {
+        waitForCallback();
+        verify(callback).onSuccess(AbstractConverterTest.VALUE);
+    }
+
+    @Override
+    public void addCallbackTo(ApiFuture<String> convertedFuture) {
+        ApiFutures.addCallback(convertedFuture, callback);
+        convertedFuture.addListener(this::callbackCalled, MoreExecutors.directExecutor());
+    }
+}

--- a/common-test/src/main/java/net/javacrumbs/futureconverter/common/test/apicommon/ApiCommonOriginalFutureTestHelper.java
+++ b/common-test/src/main/java/net/javacrumbs/futureconverter/common/test/apicommon/ApiCommonOriginalFutureTestHelper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.futureconverter.common.test.apicommon;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import net.javacrumbs.futureconverter.common.test.AbstractConverterTest;
+import net.javacrumbs.futureconverter.common.test.OriginalFutureTestHelper;
+import net.javacrumbs.futureconverter.common.test.common.CommonOriginalFutureTestHelper;
+
+import java.util.concurrent.Executors;
+
+public class ApiCommonOriginalFutureTestHelper extends CommonOriginalFutureTestHelper implements OriginalFutureTestHelper<ApiFuture<String>> {
+    private final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
+
+    @Override
+    public ApiFuture<String> createFinishedFuture() {
+        return ApiFutures.immediateFuture(AbstractConverterTest.VALUE);
+    }
+
+    @Override
+    public ApiFuture<String> createRunningFuture() {
+        return ApiFutures.transform(
+            ApiFutures.immediateFuture(""),
+            input -> {
+                try {
+                    waitForSignal();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                return AbstractConverterTest.VALUE;
+            },
+            executorService);
+    }
+
+    @Override
+    public ApiFuture<String> createExceptionalFuture(Exception exception) {
+        return ApiFutures.immediateFailedFuture(exception);
+    }
+}

--- a/java8-apifuture/pom.xml
+++ b/java8-apifuture/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>future-converter-java8-apifuture</artifactId>
+
+    <parent>
+        <groupId>net.javacrumbs.future-converter</groupId>
+        <artifactId>future-converter</artifactId>
+        <version>1.1.2-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <targetSdk>1.8</targetSdk>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>net.javacrumbs.future-converter</groupId>
+            <artifactId>future-converter-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.future-converter</groupId>
+            <artifactId>future-converter-java8-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.future-converter</groupId>
+            <artifactId>future-converter-apifuture-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.future-converter</groupId>
+            <artifactId>future-converter-common-test</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>net.javacrumbs.futureconverter.java8apifuture</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java8-apifuture/src/main/java/net/javacrumbs/futureconverter/java8apifuture/FutureConverter.java
+++ b/java8-apifuture/src/main/java/net/javacrumbs/futureconverter/java8apifuture/FutureConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.futureconverter.java8apifuture;
+
+
+import com.google.api.core.ApiFuture;
+import net.javacrumbs.futureconverter.apifuturecommon.ApiFutureUtils;
+import net.javacrumbs.futureconverter.java8common.Java8FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Converts between {@link java.util.concurrent.CompletableFuture} and Google {@link com.google.api.core.ApiFuture}.
+ */
+public class FutureConverter {
+
+    /**
+     * Converts {@link java.util.concurrent.CompletableFuture} to {@link com.google.api.core.ApiFuture}.
+     */
+    public static <T> ApiFuture<T> toApiFuture(CompletableFuture<T> completableFuture) {
+        return ApiFutureUtils.createApiFuture(Java8FutureUtils.createValueSourceFuture(completableFuture));
+    }
+
+    /**
+     * Converts  {@link com.google.api.core.ApiFuture} to {@link java.util.concurrent.CompletableFuture}.
+     */
+    public static <T> CompletableFuture<T> toCompletableFuture(ApiFuture<T> apiFuture) {
+        return Java8FutureUtils.createCompletableFuture(ApiFutureUtils.createValueSourceFuture(apiFuture));
+    }
+}

--- a/java8-apifuture/src/test/java/net/javacrumbs/futureconverter/java8apifuture/ExceptionTest.java
+++ b/java8-apifuture/src/test/java/net/javacrumbs/futureconverter/java8apifuture/ExceptionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.futureconverter.java8apifuture;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ExceptionTest {
+
+    @Test
+    public void testException() throws InterruptedException {
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        future.completeExceptionally(new RuntimeException());
+
+        future.thenApply(v-> v).exceptionally(e -> {
+                    System.out.println(e);
+                    return null;
+                });
+
+
+
+        Thread.sleep(100);
+    }
+}

--- a/java8-apifuture/src/test/java/net/javacrumbs/futureconverter/java8apifuture/ToApiFutureConverterTest.java
+++ b/java8-apifuture/src/test/java/net/javacrumbs/futureconverter/java8apifuture/ToApiFutureConverterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.futureconverter.java8apifuture;
+
+import static net.javacrumbs.futureconverter.java8apifuture.FutureConverter.toApiFuture;
+import static net.javacrumbs.futureconverter.java8apifuture.FutureConverter.toCompletableFuture;
+
+import com.google.api.core.ApiFuture;
+import jdk.nashorn.internal.ir.annotations.Ignore;
+import net.javacrumbs.futureconverter.common.test.AbstractConverterHelperBasedTest;
+import net.javacrumbs.futureconverter.common.test.apicommon.ApiCommonConvertedFutureTestHelper;
+import net.javacrumbs.futureconverter.common.test.java8.Java8OriginalFutureTestHelper;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+
+
+public class ToApiFutureConverterTest extends AbstractConverterHelperBasedTest<
+        CompletableFuture<String>,
+        ApiFuture<String>> {
+
+
+    public ToApiFutureConverterTest() {
+        super(new Java8OriginalFutureTestHelper(), new ApiCommonConvertedFutureTestHelper());
+    }
+
+    @Override
+    protected ApiFuture<String> convert(CompletableFuture<String> originalFuture) {
+        return toApiFuture(originalFuture);
+    }
+
+    @Override
+    protected CompletableFuture<String> convertBack(ApiFuture<String> converted) {
+        return toCompletableFuture(converted);
+    }
+
+    @Test
+    @Ignore
+    public void testCancelBeforeConversion() throws ExecutionException, InterruptedException {
+        // completable futures can not be canceled
+    }
+
+}

--- a/java8-apifuture/src/test/java/net/javacrumbs/futureconverter/java8apifuture/ToCompletableFutureConverterTest.java
+++ b/java8-apifuture/src/test/java/net/javacrumbs/futureconverter/java8apifuture/ToCompletableFutureConverterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.javacrumbs.futureconverter.java8apifuture;
+
+import com.google.api.core.ApiFuture;
+import net.javacrumbs.futureconverter.common.test.AbstractConverterHelperBasedTest;
+import net.javacrumbs.futureconverter.common.test.apicommon.ApiCommonOriginalFutureTestHelper;
+import net.javacrumbs.futureconverter.common.test.java8.Java8ConvertedFutureTestHelper;
+
+import java.util.concurrent.CompletableFuture;
+
+import static net.javacrumbs.futureconverter.java8apifuture.FutureConverter.toApiFuture;
+import static net.javacrumbs.futureconverter.java8apifuture.FutureConverter.toCompletableFuture;
+
+
+public class ToCompletableFutureConverterTest extends AbstractConverterHelperBasedTest<
+    ApiFuture<String>, CompletableFuture<String>> {
+
+    public ToCompletableFutureConverterTest() {
+        super(new ApiCommonOriginalFutureTestHelper(), new Java8ConvertedFutureTestHelper());
+    }
+
+    @Override
+    protected CompletableFuture<String> convert(ApiFuture<String> originalFuture) {
+        return toCompletableFuture(originalFuture);
+    }
+
+    @Override
+    protected ApiFuture<String> convertBack(CompletableFuture<String> converted) {
+        return toApiFuture(converted);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
         <module>common-test</module>
         <module>java8-common</module>
         <module>java8-guava</module>
+        <module>java8-apifuture</module>
+        <module>apifuture-common</module>
         <module>rxjava-java8</module>
         <module>rxjava-common</module>
         <module>rxjava2-common</module>
@@ -82,7 +84,12 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>18.0</version>
+                <version>20.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.api</groupId>
+                <artifactId>api-common</artifactId>
+                <version>1.7.0</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
`ApiFuture` is widely used in Google APIs, and is basically a copy-paste of `ListenableFuture` from Guava 20.0 (last one with Java 7 compatibility).

The approach here is similar, code is identical to Guava (except for one unit test).

I have no experience with RxJava or Spring futures, so I didn't dare to try and cover those combination, so only `CompletionStage` to `ApiFuture` and back are covered.